### PR TITLE
bug: Don't explode on emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "sweep-nes",
 	"displayName": "Sweep Next Edit",
 	"description": "Next Edit Autocomplete using Sweep Model",
-	"version": "0.3.6",
+	"version": "0.3.7",
 	"publisher": "SweepAI",
 	"repository": {
 		"type": "git",

--- a/src/telemetry/document-tracker.ts
+++ b/src/telemetry/document-tracker.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 
 import type { ActionType, UserAction } from "~/api/schemas.ts";
 import { toUnixPath } from "~/utils/path.ts";
+import { utf8ByteOffsetAt } from "~/utils/text.ts";
 
 interface FileSnapshot {
 	uri: string;
@@ -82,7 +83,7 @@ export class DocumentTracker implements vscode.Disposable {
 			}
 
 			const actionType = this.getActionType(change);
-			const offset = event.document.offsetAt(change.range.start);
+			const offset = utf8ByteOffsetAt(event.document, change.range.start);
 
 			this.userActions.push({
 				action_type: actionType,
@@ -100,7 +101,7 @@ export class DocumentTracker implements vscode.Disposable {
 		position: vscode.Position,
 	): void {
 		const filepath = toUnixPath(document.fileName);
-		const offset = document.offsetAt(position);
+		const offset = utf8ByteOffsetAt(document, position);
 
 		this.userActions.push({
 			action_type: "CURSOR_MOVEMENT",

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,36 @@
+import * as vscode from "vscode";
+
+export function utf8ByteOffsetAt(
+	document: vscode.TextDocument,
+	position: vscode.Position,
+): number {
+	if (position.line === 0 && position.character === 0) {
+		return 0;
+	}
+
+	const prefix = document.getText(
+		new vscode.Range(new vscode.Position(0, 0), position),
+	);
+	return Buffer.byteLength(prefix, "utf8");
+}
+
+export function utf8ByteOffsetToUtf16Offset(
+	text: string,
+	byteOffset: number,
+): number {
+	if (byteOffset <= 0) return 0;
+
+	let utf16Offset = 0;
+	let bytes = 0;
+
+	for (const ch of text) {
+		const chBytes = Buffer.byteLength(ch, "utf8");
+		if (bytes + chBytes > byteOffset) {
+			return utf16Offset;
+		}
+		bytes += chBytes;
+		utf16Offset += ch.length;
+	}
+
+	return utf16Offset;
+}


### PR DESCRIPTION
# bug
<img width="804" height="108" alt="image" src="https://github.com/user-attachments/assets/2eea2716-b54d-4f78-a37f-5b5990a7b389" />

utf 16 chars would shift everything leading to broken predictions across the system