### PR TITLE
fix: add missing shiki types deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.3.13",
+		"@shikijs/types": "^3.21.0",
+		"@shikijs/vscode-textmate": "^3.21.0",
 		"@types/bun": "1.3.7",
 		"@types/vscode": "1.108.1",
 		"@typescript/native-preview": "7.0.0-dev.20260127.1"


### PR DESCRIPTION
I was trying to build the extension locally and I noticed some packages were missing in the package.json