### PR TITLE
fix: respect fractional line height in previews

### DIFF
--- a/src/editor/preview-style.ts
+++ b/src/editor/preview-style.ts
@@ -1,0 +1,36 @@
+export interface PreviewBoxStyleInput {
+	lineCount: number;
+	maxLineLength: number;
+	fontSize: number;
+	lineHeight: number;
+	marginLeftPx?: number;
+}
+
+export function resolveLineHeight(
+	fontSize: number,
+	lineHeightSetting: number,
+): number {
+	if (lineHeightSetting > 0) {
+		if (lineHeightSetting < fontSize) {
+			return Math.ceil(fontSize * lineHeightSetting);
+		}
+		return Math.ceil(lineHeightSetting);
+	}
+	return Math.ceil(fontSize * 1.35);
+}
+
+export function computePreviewBoxStyle({
+	lineCount,
+	maxLineLength,
+	fontSize,
+	lineHeight,
+	marginLeftPx = 12,
+}: PreviewBoxStyleInput): string {
+	const safeLines = Math.max(1, lineCount);
+	const safeLineHeight = Math.max(1, lineHeight);
+	const charWidth = fontSize * 0.6;
+	const width = Math.max(1, Math.ceil(maxLineLength * charWidth));
+	const height = safeLines * safeLineHeight;
+
+	return `none; display: inline-block; vertical-align: top; height: ${height}px; width: ${width}px; margin-left: ${marginLeftPx}px`;
+}


### PR DESCRIPTION
Fixes the tiny next‑edit preview by properly handling fractional line heights and centralizing preview box sizing so the inline diff renders at readable height across themes and fonts.