### PR TITLE
feat: add local mode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,10 @@
 				"title": "Sweep: Set API Key"
 			},
 			{
+				"command": "sweep.chooseMode",
+				"title": "Sweep: Choose Mode"
+			},
+			{
 				"command": "sweep.togglePrivacyMode",
 				"title": "Sweep: Toggle Privacy Mode"
 			},
@@ -90,6 +94,26 @@
 					"scope": "window",
 					"description": "Enable or disable Sweep Next Edit suggestions"
 				},
+				"sweep.mode": {
+					"type": "string",
+					"default": "hosted",
+					"enum": [
+						"hosted",
+						"local"
+					],
+					"description": "Use hosted Sweep API or a local OpenAI-compatible server"
+				},
+				"sweep.localUrl": {
+					"type": "string",
+					"default": "http://127.0.0.1:8080",
+					"scope": "machine",
+					"description": "Base URL for local OpenAI-compatible server"
+				},
+				"sweep.metricsEnabled": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable or disable telemetry metrics"
+				},
 				"sweep.privacyMode": {
 					"type": "boolean",
 					"default": false,
@@ -120,6 +144,11 @@
 					"type": "number",
 					"default": 0,
 					"description": "Unix timestamp (ms) until which autocomplete is snoozed (0 disables snooze)"
+				},
+				"sweep.autocompleteDebounceMs": {
+					"type": "number",
+					"default": null,
+					"description": "Debounce duration (ms) for inline autocomplete requests. Leave empty to use defaults (300ms hosted, 800ms local)."
 				}
 			}
 		}

--- a/src/api/request-mode.ts
+++ b/src/api/request-mode.ts
@@ -1,0 +1,55 @@
+import type { ZodType } from "zod";
+import { resolveApiUrl, type SweepMode } from "~/core/mode";
+
+export interface AutocompleteTransport<T> {
+	apiUrl: string;
+	body: string;
+	schema: ZodType<T>;
+	compressed: boolean;
+	requiresApiKey: boolean;
+	mode: SweepMode;
+}
+
+export interface AutocompleteTransportInput<T> {
+	mode: SweepMode;
+	apiUrl: string;
+	localUrl: string;
+	hosted: {
+		body: string;
+		schema: ZodType<T>;
+		compressed: boolean;
+		requiresApiKey: boolean;
+	};
+	local: {
+		body: string;
+		schema: ZodType<T>;
+	};
+}
+
+export function buildAutocompleteTransport<T>({
+	mode,
+	apiUrl,
+	localUrl,
+	hosted,
+	local,
+}: AutocompleteTransportInput<T>): AutocompleteTransport<T> {
+	if (mode === "local") {
+		return {
+			apiUrl: resolveApiUrl(mode, localUrl),
+			body: local.body,
+			schema: local.schema,
+			compressed: false,
+			requiresApiKey: false,
+			mode,
+		};
+	}
+
+	return {
+		apiUrl,
+		body: hosted.body,
+		schema: hosted.schema,
+		compressed: hosted.compressed,
+		requiresApiKey: hosted.requiresApiKey,
+		mode,
+	};
+}

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -63,6 +63,14 @@ export const AutocompleteResponseSchema = z.object({
 		.optional(),
 });
 
+export const OpenAiCompletionResponseSchema = z.object({
+	choices: z.array(
+		z.object({
+			text: z.string(),
+		}),
+	),
+});
+
 export const SuggestionTypeSchema = z.enum([
 	"GHOST_TEXT",
 	"POPUP",
@@ -102,6 +110,9 @@ export type FileChunk = z.infer<typeof FileChunkSchema>;
 export type UserAction = z.infer<typeof UserActionSchema>;
 export type AutocompleteRequest = z.infer<typeof AutocompleteRequestSchema>;
 export type AutocompleteResponse = z.infer<typeof AutocompleteResponseSchema>;
+export type OpenAiCompletionResponse = z.infer<
+	typeof OpenAiCompletionResponseSchema
+>;
 export type AutocompleteMetricsRequest = z.infer<
 	typeof AutocompleteMetricsRequestSchema
 >;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,7 +1,8 @@
 import * as path from "node:path";
 import * as vscode from "vscode";
 
-import { DEFAULT_MAX_CONTEXT_FILES } from "~/core/constants.ts";
+import { DEFAULT_LOCAL_API_URL, DEFAULT_MAX_CONTEXT_FILES } from "~/core/constants.ts";
+import type { SweepMode } from "~/core/mode.ts";
 
 const SWEEP_CONFIG_SECTION = "sweep";
 
@@ -16,6 +17,18 @@ export class SweepConfig {
 
 	get enabled(): boolean {
 		return this.config.get<boolean>("enabled", true);
+	}
+
+	get mode(): SweepMode {
+		return this.config.get<SweepMode>("mode", "hosted");
+	}
+
+	get localUrl(): string {
+		return this.config.get<string>("localUrl", DEFAULT_LOCAL_API_URL);
+	}
+
+	get metricsEnabled(): boolean {
+		return this.config.get<boolean>("metricsEnabled", true);
 	}
 
 	get privacyMode(): boolean {
@@ -35,6 +48,10 @@ export class SweepConfig {
 
 	get autocompleteSnoozeUntil(): number {
 		return this.config.get<number>("autocompleteSnoozeUntil", 0);
+	}
+
+	get autocompleteDebounceMs(): number | undefined {
+		return this.config.get<number | undefined>("autocompleteDebounceMs");
 	}
 
 	isAutocompleteSnoozed(now = Date.now()): boolean {
@@ -87,6 +104,13 @@ export class SweepConfig {
 		target: vscode.ConfigurationTarget = this.getWorkspaceTarget(),
 	): Thenable<void> {
 		return this.config.update("privacyMode", value, target);
+	}
+
+	setMode(
+		value: "hosted" | "local",
+		target: vscode.ConfigurationTarget = vscode.ConfigurationTarget.Global,
+	): Thenable<void> {
+		return this.config.update("mode", value, target);
 	}
 
 	setAutocompleteSnoozeUntil(

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -7,7 +7,9 @@ export const DEFAULT_API_ENDPOINT =
 	"https://autocomplete.sweep.dev/backend/next_edit_autocomplete";
 export const DEFAULT_METRICS_ENDPOINT =
 	"https://backend.app.sweep.dev/backend/track_autocomplete_metrics";
+export const DEFAULT_LOCAL_API_URL = "http://127.0.0.1:8080";
 export const DEFAULT_MAX_CONTEXT_FILES = 5;
+export const LOCAL_CONTEXT_LINE_RADIUS = 40;
 
 // Model parameters
 export const MODEL_NAME = "sweepai/sweep-next-edit";

--- a/src/core/mode.ts
+++ b/src/core/mode.ts
@@ -1,0 +1,30 @@
+import {
+  DEFAULT_API_ENDPOINT,
+  DEFAULT_LOCAL_API_URL,
+} from "~/core/constants";
+
+export type SweepMode = "hosted" | "local";
+
+const DEFAULT_LOCAL_COMPLETIONS_PATH = "/v1/completions";
+
+export function resolveApiUrl(mode: SweepMode, localUrl: string): string {
+  if (mode !== "local") return DEFAULT_API_ENDPOINT;
+  const trimmed = localUrl.trim();
+  const base = trimmed.length > 0 ? trimmed : DEFAULT_LOCAL_API_URL;
+  try {
+    const url = new URL(base);
+    const pathname = url.pathname.replace(/\/+$/, "");
+    if (pathname === "" || pathname === "/") {
+      url.pathname = DEFAULT_LOCAL_COMPLETIONS_PATH;
+    } else {
+      url.pathname = pathname;
+    }
+    return url.toString();
+  } catch {
+    return base.replace(/\/+$/, "");
+  }
+}
+
+export function shouldRequireApiKey(mode: SweepMode): boolean {
+  return mode !== "local";
+}

--- a/src/editor/request-policy.ts
+++ b/src/editor/request-policy.ts
@@ -1,0 +1,37 @@
+import type { SweepMode } from "~/core/mode.ts";
+
+export interface InlineRequestPolicy {
+	cancelOnNewRequest: boolean;
+	respectCancellation: boolean;
+}
+
+const HOSTED_INLINE_DEBOUNCE_MS = 300;
+const LOCAL_INLINE_DEBOUNCE_MS = 800;
+const INLINE_DEBOUNCE_MIN_MS = 100;
+
+export function getInlineRequestPolicy(mode: SweepMode): InlineRequestPolicy {
+	if (mode === "local") {
+		return {
+			cancelOnNewRequest: false,
+			respectCancellation: false,
+		};
+	}
+
+	return {
+		cancelOnNewRequest: true,
+		respectCancellation: true,
+	};
+}
+
+export function resolveInlineDebounceMs(
+	mode: SweepMode,
+	configuredValue?: number,
+): number {
+	const base =
+		typeof configuredValue === "number" && !Number.isNaN(configuredValue)
+			? configuredValue
+			: mode === "local"
+				? LOCAL_INLINE_DEBOUNCE_MS
+				: HOSTED_INLINE_DEBOUNCE_MS;
+	return Math.max(INLINE_DEBOUNCE_MIN_MS, Math.floor(base));
+}

--- a/src/extension/activate.ts
+++ b/src/extension/activate.ts
@@ -59,22 +59,20 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	const triggerCommand = vscode.commands.registerCommand(
 		"sweep.triggerNextEdit",
-		() => {
-			vscode.commands
-				.executeCommand("editor.action.inlineEdit.trigger")
-				.then((result) => {
-					if (result === undefined) {
-						console.log(
-							"[Sweep] Triggered inline edit command successfully",
-						);
-					}
-				})
-				.catch((error) => {
-					console.error(
-						"[Sweep] Failed to trigger inline edit command:",
-						error,
-					);
-				});
+		async () => {
+			try {
+				const result = await vscode.commands.executeCommand(
+					"editor.action.inlineEdit.trigger",
+				);
+				if (result === undefined) {
+					console.log("[Sweep] Triggered inline edit command successfully");
+				}
+			} catch (error) {
+				console.error(
+					"[Sweep] Failed to trigger inline edit command:",
+					error,
+				);
+			}
 		},
 	);
 

--- a/src/extension/activate.ts
+++ b/src/extension/activate.ts
@@ -19,6 +19,8 @@ import {
 import { DocumentTracker } from "~/telemetry/document-tracker.ts";
 
 const API_KEY_PROMPT_SHOWN = "sweep.apiKeyPromptShown";
+const ONBOARDING_COMPLETE = "sweep.onboardingComplete";
+const MODE_COMMAND = "sweep.chooseMode";
 
 let tracker: DocumentTracker;
 let jumpEditManager: JumpEditManager;
@@ -26,8 +28,11 @@ let provider: InlineEditProvider;
 let statusBar: SweepStatusBar;
 let metricsTracker: AutocompleteMetricsTracker;
 
-export function activate(context: vscode.ExtensionContext) {
-	promptForApiKeyIfNeeded(context);
+export async function activate(context: vscode.ExtensionContext) {
+	const chosen = await maybeRunOnboarding(context);
+	if (chosen !== "local") {
+		promptForApiKeyIfNeeded(context);
+	}
 
 	initSyntaxHighlighter();
 
@@ -55,13 +60,34 @@ export function activate(context: vscode.ExtensionContext) {
 	const triggerCommand = vscode.commands.registerCommand(
 		"sweep.triggerNextEdit",
 		() => {
-			vscode.commands.executeCommand("editor.action.inlineEdit.trigger");
+			vscode.commands
+				.executeCommand("editor.action.inlineEdit.trigger")
+				.then((result) => {
+					if (result === undefined) {
+						console.log(
+							"[Sweep] Triggered inline edit command successfully",
+						);
+					}
+				})
+				.catch((error) => {
+					console.error(
+						"[Sweep] Failed to trigger inline edit command:",
+						error,
+					);
+				});
 		},
 	);
 
 	const setApiKeyCommand = vscode.commands.registerCommand(
 		"sweep.setApiKey",
 		promptSetApiKey,
+	);
+
+	const chooseModeCommand = vscode.commands.registerCommand(
+		MODE_COMMAND,
+		async () => {
+			await chooseMode(context);
+		},
 	);
 
 	const acceptJumpEditCommand = vscode.commands.registerCommand(
@@ -156,6 +182,7 @@ export function activate(context: vscode.ExtensionContext) {
 		providerDisposable,
 		triggerCommand,
 		setApiKeyCommand,
+		chooseModeCommand,
 		acceptJumpEditCommand,
 		acceptInlineEditCommand,
 		dismissJumpEditCommand,
@@ -174,9 +201,48 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {}
 
+type ModeQuickPickItem = vscode.QuickPickItem & {
+	mode: "local" | "hosted";
+};
+
+const MODE_QUICK_PICK_ITEMS: ModeQuickPickItem[] = [
+	{
+		label: "Local (llama.cpp)",
+		description: "Use a local OpenAI-compatible server",
+		mode: "local",
+	},
+	{
+		label: "Hosted (Sweep API)",
+		description: "Use Sweep's hosted service",
+		mode: "hosted",
+	},
+];
+
+async function chooseMode(
+	context: vscode.ExtensionContext,
+): Promise<"local" | "hosted" | null> {
+	const pick = await vscode.window.showQuickPick(MODE_QUICK_PICK_ITEMS, {
+		placeHolder: "Choose Sweep mode",
+	});
+	if (!pick) return null;
+	await config.setMode(pick.mode, vscode.ConfigurationTarget.Global);
+	await context.globalState.update(ONBOARDING_COMPLETE, true);
+	return pick.mode;
+}
+
+async function maybeRunOnboarding(
+	context: vscode.ExtensionContext,
+): Promise<"local" | "hosted" | null> {
+	const done = context.globalState.get<boolean>(ONBOARDING_COMPLETE, false);
+	if (done) return null;
+	return chooseMode(context);
+}
+
 async function promptForApiKeyIfNeeded(
 	context: vscode.ExtensionContext,
 ): Promise<void> {
+	if (config.mode === "local") return;
+
 	const apiKey = config.apiKey;
 
 	if (apiKey) return;
@@ -187,6 +253,7 @@ async function promptForApiKeyIfNeeded(
 	);
 	if (hasPrompted) return;
 
+	console.log("[Sweep] Prompting for API key");
 	await promptSetApiKey();
 
 	await context.globalState.update(API_KEY_PROMPT_SHOWN, true);

--- a/src/local/completions.ts
+++ b/src/local/completions.ts
@@ -1,0 +1,59 @@
+import { SWEEP_FILE_SEP_TOKEN } from "~/core/constants.ts";
+import { toUnixPath } from "~/utils/path.ts";
+
+export interface LocalPromptInput {
+	filePath: string;
+	originalText: string;
+	currentText: string;
+}
+
+export interface ReplacementSpan {
+	start: number;
+	end: number;
+	replacement: string;
+}
+
+export function buildLocalPrompt(input: LocalPromptInput): string {
+	const filePath = toUnixPath(input.filePath) || input.filePath || "untitled";
+	const originalText = input.originalText ?? "";
+	const currentText = input.currentText ?? "";
+
+	return [
+		`${SWEEP_FILE_SEP_TOKEN}original/${filePath}`,
+		originalText,
+		`${SWEEP_FILE_SEP_TOKEN}current/${filePath}`,
+		currentText,
+		`${SWEEP_FILE_SEP_TOKEN}updated/${filePath}`,
+		"",
+	].join("\n");
+}
+
+export function computeReplacementSpan(
+	currentText: string,
+	updatedText: string,
+): ReplacementSpan | null {
+	if (currentText === updatedText) return null;
+
+	let start = 0;
+	const minLen = Math.min(currentText.length, updatedText.length);
+	while (start < minLen && currentText[start] === updatedText[start]) {
+		start += 1;
+	}
+
+	let endCurrent = currentText.length;
+	let endUpdated = updatedText.length;
+	while (
+		endCurrent > start &&
+		endUpdated > start &&
+		currentText[endCurrent - 1] === updatedText[endUpdated - 1]
+	) {
+		endCurrent -= 1;
+		endUpdated -= 1;
+	}
+
+	return {
+		start,
+		end: endCurrent,
+		replacement: updatedText.slice(start, endUpdated),
+	};
+}


### PR DESCRIPTION
closes #26 

This adds a local mode so the extension can talk to an OpenAI‑compatible server (like llama-cpp) instead of the hosted Sweep API. The request path is now shared for both modes, with a small local adapter that builds the prompt and parses OpenAI‑style completions. Activation now includes a quick mode chooser, and inline edits use a debounced + cancellable request flow to keep things responsive (since local llms are slower on consumer gpus)

I've ran my llama-server with this command:
```bash
llama-server -m 'sweep-next-edit-1.5b.q8_0.v2.gguf' -c 8192 --port 8080 -ngl 99 -v
```
And it seems to work fine on my end.